### PR TITLE
feat: reset the form

### DIFF
--- a/src/web/extension-services/background/handlers/handleActions.ts
+++ b/src/web/extension-services/background/handlers/handleActions.ts
@@ -610,7 +610,6 @@ export const handleActions = async (
         await mainCtrl.buildTransferUserRequest(fromAmount, recipientAddress, fromSelectedToken)
       }
 
-      mainCtrl.transactionManager.formState.resetForm()
       mainCtrl.transactionManager.intent.setQuoteAndTransaction([], [])
 
       break

--- a/src/web/modules/intent/components/Estimation/SignAccountOp/screens/SignAccountOpScreen/SignAccountOpScreen.tsx
+++ b/src/web/modules/intent/components/Estimation/SignAccountOp/screens/SignAccountOpScreen/SignAccountOpScreen.tsx
@@ -71,6 +71,7 @@ const SignAccountOpScreen = ({ closeEstimationModal }: Props) => {
       type: 'MAIN_CONTROLLER_HANDLE_SIGN_AND_BROADCAST_ACCOUNT_OP'
     })
   }, [dispatch])
+
   const {
     renderedButNotNecessarilyVisibleModal,
     isViewOnly,


### PR DESCRIPTION
## Describe your changes
- Added hook to clean the recipient state when the form is cleared.
- Removed the reset call from the handleActions, this ocurr when the user hit Proceed, but at this time is possible to cancel the transaction, and the form should not be cleared.
- Added a small debounce when updating the state to the backend.
- Moved all the useEffect to a single place for better readability.

## Issue ticket number and link

closes https://linear.app/defi-wonderland/issue/EFI-302/last-entered-transfer-data-persist