### PR TITLE
fix: 🐛 now all items can be selected

### DIFF
--- a/src/web/modules/intent/components/FromToken.tsx
+++ b/src/web/modules/intent/components/FromToken.tsx
@@ -30,8 +30,7 @@ const FromToken: FC<Props> = ({
 }) => {
   const { networks } = useNetworksControllerState()
   const { dispatch } = useBackgroundService()
-  const { fromAmount, fromAmountInFiat, fromSelectedToken, toSelectedToken, maxFromAmount } =
-    useTransactionForm()
+  const { fromAmount, fromAmountInFiat, fromSelectedToken, maxFromAmount } = useTransactionForm()
   const { portfolioTokenList, fromAmountFieldMode, validateFromAmount } =
     useSwapAndBridgeControllerState()
 
@@ -43,25 +42,12 @@ const FromToken: FC<Props> = ({
 
       setIsAutoSelectRouteDisabled(false)
 
-      // Switch the tokens if the selected token is the same as the "to" token
-      if (
-        tokenToSelect &&
-        toSelectedToken &&
-        tokenToSelect.address === toSelectedToken.address &&
-        tokenToSelect.chainId === BigInt(toSelectedToken.chainId || 0)
-      ) {
-        dispatch({
-          type: 'SWAP_AND_BRIDGE_CONTROLLER_SWITCH_FROM_AND_TO_TOKENS'
-        })
-        return
-      }
-
       dispatch({
         type: 'TRANSACTION_CONTROLLER_UPDATE_FORM',
         params: { fromSelectedToken: tokenToSelect }
       })
     },
-    [portfolioTokenList, setIsAutoSelectRouteDisabled, toSelectedToken, dispatch, networks]
+    [portfolioTokenList, setIsAutoSelectRouteDisabled, dispatch, networks]
   )
 
   const handleSetMaxFromAmount = useCallback(() => {


### PR DESCRIPTION
## Describe your changes
- removed unnecessary dispatch and dependency that conflict with the selected values

## Issue ticket number and link

closes https://linear.app/defi-wonderland/issue/EFI-301/tokenchain-dropdown-does-not-reflect-the-most-recent-selection
